### PR TITLE
feat: add external database config

### DIFF
--- a/terminfinder-chart/charts/terminfinder-backend/templates/_helpers.tpl
+++ b/terminfinder-chart/charts/terminfinder-backend/templates/_helpers.tpl
@@ -60,3 +60,81 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Check if external db and postgres are not used at the same time
+*/}}
+{{- define "terminfinder-backend.check-database-values" -}}
+{{- if and .Values.externalDatabase.enabled .Values.postgresql.enabled }}
+{{- fail "It's not possible to use an external database and a Postgres DB subchart at the same time." -}}
+{{- end }}
+{{- if and (not .Values.externalDatabase.enabled) (not .Values.postgresql.enabled) }}
+{{- (printf "no database is enabled check-database-values %b" .Values.externalDatabase.enabled) | fail }}
+{{- end }}
+{{- end }}
+
+{{- define "terminfinder-backend.database-server-address" -}}
+{{- include "terminfinder-backend.check-database-values" . }}
+{{- if .Values.externalDatabase.enabled }}
+{{- .Values.externalDatabase.address }}
+{{- else if .Values.postgresql.enabled }}
+{{- printf "%s-postgresql" .Release.Name }}
+{{- else }}
+{{- fail "no database is enabled database-server-address" }}
+{{- end }}
+{{- end }}
+
+{{- define "terminfinder-backend.database-name" -}}
+{{- include "terminfinder-backend.check-database-values" . }}
+{{- if .Values.externalDatabase.enabled }}
+{{- .Values.externalDatabase.database }}
+{{- else if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.database }}
+{{- else }}
+{{- fail "no database is enabled database-name" }}
+{{- end }}
+{{- end }}
+
+{{- define "terminfinder-backend.database-port" -}}
+{{- include "terminfinder-backend.check-database-values" . }}
+{{- if .Values.externalDatabase.enabled }}
+{{- .Values.externalDatabase.port | quote }}
+{{- else if .Values.postgresql.enabled }}
+{{- .Values.postgresql.primary.service.ports.postgresql | quote }}
+{{- else }}
+{{- fail "no database is enabled database-port" }}
+{{- end }}
+{{- end }}
+
+{{- define "terminfinder-backend.database-username" -}}
+{{- include "terminfinder-backend.check-database-values" . }}
+{{- if .Values.externalDatabase.enabled }}
+{{- .Values.externalDatabase.username }}
+{{- else if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.username }}
+{{- else }}
+{{- fail "no database is enabled database-username" }}
+{{- end }}
+{{- end }}
+
+{{- define "terminfinder-backend.database-existingSecret" -}}
+{{- include "terminfinder-backend.check-database-values" . }}
+{{- if .Values.externalDatabase.enabled }}
+{{- .Values.externalDatabase.existingSecret }}
+{{- else if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.existingSecret }}
+{{- else }}
+{{- fail "no database is enabled database-existingSecret" }}
+{{- end }}
+{{- end }}
+
+{{- define "terminfinder-backend.database-userPasswordKey" -}}
+{{- include "terminfinder-backend.check-database-values" . }}
+{{- if .Values.externalDatabase.enabled }}
+{{- .Values.externalDatabase.secretKeys.userPasswordKey }}
+{{- else if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.secretKeys.userPasswordKey }}
+{{- else }}
+{{- fail "no database is enabled database-userPasswordKey" }}
+{{- end }}
+{{- end }}

--- a/terminfinder-chart/charts/terminfinder-backend/templates/deployment.yaml
+++ b/terminfinder-chart/charts/terminfinder-backend/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- $svc :=  printf "%s-postgresql" .Release.Name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,20 +36,20 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DB_DATABASE
-              value: {{ .Values.global.postgresql.auth.database }}
+              value: {{ include "terminfinder-backend.database-name" . }}
             - name: DB_PORT
-              value: {{ .Values.global.postgresql.service.ports.postgresql | quote }}
+              value: {{ include "terminfinder-backend.database-port" . }}
             - name: DB_ADDRESS
-              value: {{ printf "%s" $svc }}
+              value: {{ include "terminfinder-backend.database-server-address" . }}
             - name: DB_USERNAME
-              value: {{ .Values.global.postgresql.auth.username }}
-            - name: ASPNETCORE_URLS
-              value: {{printf "http://+:%d" (int .Values.application.port) }}
+              value: {{ include "terminfinder-backend.database-username" . }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "Postgres DB secret name not set" .Values.global.postgresql.auth.existingSecret }}
-                  key: {{ required "Postgres DB password secretkey not set" .Values.global.postgresql.auth.secretKeys.userPasswordKey }}
+                  name: {{ include "terminfinder-backend.database-existingSecret" . }}
+                  key: {{ include "terminfinder-backend.database-userPasswordKey" . }}
+            - name: ASPNETCORE_URLS
+              value: {{printf "http://+:%d" (int .Values.application.port) }}
             - name: Terminfinder__UseHttps
               value: "false"
             - name: Terminfinder__UseCors

--- a/terminfinder-chart/charts/terminfinder-backend/values.yaml
+++ b/terminfinder-chart/charts/terminfinder-backend/values.yaml
@@ -1,15 +1,3 @@
-global:
-  postgresql:
-    auth:
-      database: terminfinder
-      username: terminfinder
-      existingSecret: postgresql-default-auth
-      secretKeys:
-        userPasswordKey: password
-    service:
-      ports:
-        postgresql: 5432
-
 replicaCount: 1
 
 image:
@@ -87,10 +75,24 @@ tolerations: [ ]
 
 affinity: { }
 
+externalDatabase:
+  enabled: false
+  address: null
+  port: null
+  database: null
+  username: null
+  existingSecret: null
+  secretKeys:
+    userPasswordKey: null
+
 postgresql:
   enabled: true
 
+  fullnameOverride: null
+
   auth:
+    database: terminfinder
+    username: terminfinder
     enablePostgresUser: false
 
   primary:

--- a/terminfinder-chart/charts/terminfinder-frontend/templates/deployment.yaml
+++ b/terminfinder-chart/charts/terminfinder-frontend/templates/deployment.yaml
@@ -36,17 +36,17 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: CUSTOMER_ID
-              value: {{ required "no customerId set" .Values.application.customerId }}
+              value: {{ required "no customerId set" .Values.customerConfig.customerId }}
             - name: API_URL
               value: {{ .Values.application.apiUrl }}
             - name: TITLE
-              value: {{ .Values.application.title }}
+              value: {{ .Values.customerConfig.title }}
             - name: LOCALE
-              value: {{ required "no locale set" .Values.application.locale }}
+              value: {{ required "no locale set" .Values.customerConfig.locale }}
             - name: ADDRESSING
-              value: {{ required "no addressing set" .Values.application.addressing }}
+              value: {{ required "no addressing set" .Values.customerConfig.addressing }}
             - name: EMAIL
-              value: {{ required "no email set" .Values.application.email }}
+              value: {{ required "no email set" .Values.customerConfig.email }}
           ports:
             - name: http
               containerPort: 8080

--- a/terminfinder-chart/charts/terminfinder-frontend/values.yaml
+++ b/terminfinder-chart/charts/terminfinder-frontend/values.yaml
@@ -1,10 +1,12 @@
-application:
+customerConfig:
   customerId: "80248A42-8FE2-4D4A-89DA-02E683511F76"
-  apiUrl: ""
   title: ""
   locale: "de-DE"
   addressing: "du"
   email: "demo@demo.demo"
+
+application:
+  apiUrl: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
BREAKING CHANGE: add `customerConfig` values to be set by clients; `application` values to be set by operators

fix #19 